### PR TITLE
At least test it

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
@@ -37,6 +37,7 @@ public class Command_links extends FreedomCommand
         if (lines.size() == 0)
         {
             lines.add(ChatColor.GOLD + "- There are no links currently added in the config.");
+            return true;
         }
 
         lines.add(ChatColor.AQUA + "TotalFreedom Social Media Links:");

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
@@ -18,32 +18,29 @@ public class Command_links extends FreedomCommand
     @Override
     protected boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
     {
-    ConfigurationSection section = plugin.getConfig().getConfigurationSection("social_links");
-        if (section != null)
+            ConfigurationSection section = plugin.getConfig().getConfigurationSection("social_links");
+        if (section != null) { 
+        Map<String, Object> values = section.getValues(false);
+
+        List<String> lines = new ArrayList<>();
+
+        for (String key : values.keySet())
         {
-            Map<String, Object> values = section.getValues(false);
-
-            List<String> lines = new ArrayList<>();
-
-            for (String key : values.keySet())
+            if (!(values.get(key) instanceof String))
             {
-                if (!(values.get(key) instanceof String))
-                {
-                    continue;
-                }
-
-                String link = (String) values.get(key);
-
-                lines.add(ChatColor.GOLD + "- " + key + ": " + ChatColor.AQUA + link);
+                continue;
             }
-
-            sender.sendMessage(ChatColor.AQUA + "Social Media Links:");
-            sender.sendMessage(lines.toArray(new String[0]));
-            return true;
-        } else
-        {
-            sender.sendMessage(ChatColor.RED + "There are no links added in the configuration file.");
+            String link = (String) values.get(key);
+            lines.add(ChatColor.GOLD + "- " + key + ": " + ChatColor.AQUA + link); 
         }
-        return true;
+
+        sender.sendMessage(ChatColor.AQUA + "Social Media Links:");
+        sender.sendMessage(lines.toArray(new String[0]));
+        return true; 
+        } else 
+            { 
+                sender.sendMessage(ChatColor.RED + "There are no links added in the configuration file."); 
+            }
+            return true;
     }
 }

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
@@ -18,7 +18,7 @@ public class Command_links extends FreedomCommand
     @Override
     protected boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
     {
-            ConfigurationSection section = plugin.getConfig().getConfigurationSection("social_links");
+        ConfigurationSection section = plugin.getConfig().getConfigurationSection("social_links");
         if (section != null) { 
         Map<String, Object> values = section.getValues(false);
 

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
@@ -13,17 +13,22 @@ import java.util.Map;
 
 @CommandPermissions(level = Rank.OP, source = SourceType.BOTH)
 @CommandParameters(description = "Get social media links.", usage = "/<command>", aliases = "link")
-public class Command_links extends FreedomCommand {
+public class Command_links extends FreedomCommand
+{
     @Override
-    protected boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole) {
+    protected boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
+    {
         ConfigurationSection section = plugin.getConfig().getConfigurationSection("social_links");
-        if (section != null) {
+        if (section != null)
+        {
             Map<String, Object> values = section.getValues(false);
 
             List<String> lines = new ArrayList<>();
 
-            for (String key : values.keySet()) {
-                if (!(values.get(key) instanceof String)) {
+            for (String key : values.keySet())
+            {
+                if (!(values.get(key) instanceof String))
+                {
                     continue;
                 }
                 String link = (String) values.get(key);
@@ -33,7 +38,9 @@ public class Command_links extends FreedomCommand {
             sender.sendMessage(ChatColor.AQUA + "Social Media Links:");
             sender.sendMessage(lines.toArray(new String[0]));
             return true;
-        } else {
+        }
+        else
+        {
             sender.sendMessage(ChatColor.RED + "There are no links added in the configuration file.");
         }
         return true;

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
@@ -18,31 +18,32 @@ public class Command_links extends FreedomCommand
     @Override
     protected boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
     {
-        ConfigurationSection section = plugin.getConfig().getConfigurationSection("social_links");
-        Map<String,Object> values = section.getValues(false);
-
-        List<String> lines = new ArrayList<>();
-
-        for (String key : values.keySet())
+    ConfigurationSection section = plugin.getConfig().getConfigurationSection("social_links");
+        if (section != null)
         {
-            if (!(values.get(key) instanceof String))
+            Map<String, Object> values = section.getValues(false);
+
+            List<String> lines = new ArrayList<>();
+
+            for (String key : values.keySet())
             {
-                continue;
+                if (!(values.get(key) instanceof String))
+                {
+                    continue;
+                }
+
+                String link = (String) values.get(key);
+
+                lines.add(ChatColor.GOLD + "- " + key + ": " + ChatColor.AQUA + link);
             }
 
-            String link = (String) values.get(key);
-
-            lines.add(ChatColor.GOLD + "- " + key + ": " + ChatColor.AQUA + link);
-        }
-        if (lines.size() == 0)
-        {
-            sender.sendMessage(ChatColor.GOLD + "- There are no links currently added in the configuration file.");
+            sender.sendMessage(ChatColor.AQUA + "Social Media Links:");
+            sender.sendMessage(lines.toArray(new String[0]));
             return true;
+        } else
+        {
+            sender.sendMessage(ChatColor.RED + "There are no links added in the configuration file.");
         }
-
-        sender.sendMessage(ChatColor.AQUA + "TotalFreedom Social Media Links:");
-        sender.sendMessage(lines.toArray(new String[0]));
-
         return true;
     }
 }

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
@@ -37,10 +37,9 @@ public class Command_links extends FreedomCommand
         sender.sendMessage(ChatColor.AQUA + "Social Media Links:");
         sender.sendMessage(lines.toArray(new String[0]));
         return true; 
-        } else 
-            { 
-                sender.sendMessage(ChatColor.RED + "There are no links added in the configuration file."); 
-            }
-            return true;
+        } else {
+        sender.sendMessage(ChatColor.RED + "There are no links added in the configuration file."); 
+        }
+        return true;
     }
 }

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
@@ -13,32 +13,28 @@ import java.util.Map;
 
 @CommandPermissions(level = Rank.OP, source = SourceType.BOTH)
 @CommandParameters(description = "Get social media links.", usage = "/<command>", aliases = "link")
-public class Command_links extends FreedomCommand
-{
+public class Command_links extends FreedomCommand {
     @Override
-    protected boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
-    {
+    protected boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole) {
         ConfigurationSection section = plugin.getConfig().getConfigurationSection("social_links");
-        if (section != null) { 
-        Map<String, Object> values = section.getValues(false);
+        if (section != null) {
+            Map<String, Object> values = section.getValues(false);
 
-        List<String> lines = new ArrayList<>();
+            List<String> lines = new ArrayList<>();
 
-        for (String key : values.keySet())
-        {
-            if (!(values.get(key) instanceof String))
-            {
-                continue;
+            for (String key : values.keySet()) {
+                if (!(values.get(key) instanceof String)) {
+                    continue;
+                }
+                String link = (String) values.get(key);
+                lines.add(ChatColor.GOLD + "- " + key + ": " + ChatColor.AQUA + link);
             }
-            String link = (String) values.get(key);
-            lines.add(ChatColor.GOLD + "- " + key + ": " + ChatColor.AQUA + link); 
-        }
 
-        sender.sendMessage(ChatColor.AQUA + "Social Media Links:");
-        sender.sendMessage(lines.toArray(new String[0]));
-        return true; 
+            sender.sendMessage(ChatColor.AQUA + "Social Media Links:");
+            sender.sendMessage(lines.toArray(new String[0]));
+            return true;
         } else {
-        sender.sendMessage(ChatColor.RED + "There are no links added in the configuration file."); 
+            sender.sendMessage(ChatColor.RED + "There are no links added in the configuration file.");
         }
         return true;
     }

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_links.java
@@ -36,11 +36,11 @@ public class Command_links extends FreedomCommand
         }
         if (lines.size() == 0)
         {
-            lines.add(ChatColor.GOLD + "- There are no links currently added in the config.");
+            sender.sendMessage(ChatColor.GOLD + "- There are no links currently added in the configuration file.");
             return true;
         }
 
-        lines.add(ChatColor.AQUA + "TotalFreedom Social Media Links:");
+        sender.sendMessage(ChatColor.AQUA + "TotalFreedom Social Media Links:");
         sender.sendMessage(lines.toArray(new String[0]));
 
         return true;


### PR DESCRIPTION
It will still throw a NPE whenever the social links is like this
social_links: []
The way that it is written makes it so that it doesn't throw the NPE when the social links looks like this:
social_links: []

I fixed that bug and also another bug. You should use sender.sendMessage (or msg, or however TFM does it???) instead of lines.add, and fixed the wording of the message a little