### PR TITLE
Fix EntityWiper not registering dropped items

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
@@ -6,9 +6,12 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import lombok.Getter;
 import me.totalfreedom.totalfreedommod.config.ConfigEntry;
 import me.totalfreedom.totalfreedommod.util.FUtil;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
 import org.bukkit.World;
 import org.bukkit.entity.AreaEffectCloud;
@@ -32,12 +35,15 @@ import org.bukkit.entity.EnderPearl;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.ItemSpawnEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
 public class EntityWiper extends FreedomService
 {
 
+    @Getter
+    private boolean enabled;
     public static final long ENTITY_WIPE_RATE = 5 * 20L;
     public static final long ITEM_DESPAWN_RATE = 20L * 20L;
     public static final int CHUNK_ENTITY_MAX = 20;
@@ -196,4 +202,13 @@ public class EntityWiper extends FreedomService
 
     }
 
+    @EventHandler
+    public void onDrop(PlayerDropItemEvent event)
+    {
+        enabled = ConfigEntry.AUTO_ENTITY_WIPE.getBoolean();
+        if (enabled)
+        {
+            event.setCancelled(true);
+        }
+    }
 }

--- a/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
@@ -11,7 +11,6 @@ import lombok.Getter;
 import me.totalfreedom.totalfreedommod.config.ConfigEntry;
 import me.totalfreedom.totalfreedommod.util.FUtil;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
 import org.bukkit.World;
 import org.bukkit.entity.AreaEffectCloud;


### PR DESCRIPTION
So here's the issue: The command /ew works fine, and does clear entities. However, the way death items are spread is through operators dropping the items. What I am fixing is when you type /toggle entitywipe, it will actually wipe entities when you drop them. This will prevent players from dropping death items. In conjunction with https://github.com/TFPatches/TF-EssentialsX/releases/tag/2.15.0, this should get rid of the method operators use to spread death items.