### PR TITLE
Fix NPE in /list

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/admin/Admin.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/admin/Admin.java
@@ -57,10 +57,10 @@ public class Admin implements ConfigLoadable, ConfigSavable, Validatable
     private String acFormat = null;
     @Getter
     @Setter
-    private Boolean oldTags = null;
+    private Boolean oldTags = false;
     @Getter
     @Setter
-    private Boolean logStick = null;
+    private Boolean logStick = false;
 
     public static final String CONFIG_FILENAME = "admins.yml";
 
@@ -89,7 +89,10 @@ public class Admin implements ConfigLoadable, ConfigSavable, Validatable
                 .append("- Is Active: ").append(active).append("\n")
                 .append("- Discord ID: ").append(discordID).append("\n")
                 .append("- Tag: ").append(tag).append("\n")
-                .append("- Admin Chat Format:").append(acFormat);
+                .append("- Potion Spy: ").append(potionSpy).append("\n")
+                .append("- Admin Chat Format: ").append(acFormat).append("\n")
+                .append("- Old Tags: ").append(oldTags).append("\n")
+                .append("- Log Stick: ").append(logStick);
 
         return output.toString();
     }


### PR DESCRIPTION
- This fixes a NPE in /list. When an admin gets added (not activated, but a new entry is made), and they do /list, it will cause /list to give them a NPE. The reasoning for this is because when an admin would get added, it would set oldTags to null, rather than false. The way to fix it would be to reload the server.
- Additionally, this includes all of the new information that has been added to display when doing /saconfig info on an admin 