### PR TITLE
Replace ${git.commit.id.abbrev} with unknown

### DIFF
--- a/TotalFreedomMod.iml
+++ b/TotalFreedomMod.iml
@@ -11,6 +11,9 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Maven: org.bstats:bstats-bukkit:1.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.TFPatches:TF-WorldEdit:2e79570525" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.avaje:ebean:2.7.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.bukkit:bukkit:1.13-R0.1-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.projectlombok:lombok:1.18.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot:1.13-R0.1-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.Pravian:Aero:5f82926" level="project" />
@@ -34,6 +37,9 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.TFPatches:TF-WorldEdit:2e79570525" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.TFPatches.TF-WorldEdit:worldedit-bukkit:2e79570525" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.sk89q:dummypermscompat:1.8" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.bukkit:bukkit:1.9.4-R0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.avaje:ebean:2.8.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.persistence:persistence-api:1.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.github.TFPatches.TF-WorldEdit:worldedit-core:2e79570525" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: de.schlichtherle:truezip:6.8.3" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: rhino:js:1.7R2" level="project" />
@@ -41,8 +47,6 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.thoughtworks.paranamer:paranamer:2.6" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.sk89q.lib:jlibnoise:1.0.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.sk89q.bukkit:bukkit-classloader-check:1.7.9-R0.2" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.avaje:ebean:2.7.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.persistence:persistence-api:1.0" level="project" />
     <orderEntry type="module-library">
       <library name="Maven: com.sk89q.worldedit:worldedit-bukkit:7.0.0-SNAPSHOT">
         <CLASSES>
@@ -68,7 +72,6 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.squareup.okhttp3:okhttp:3.8.1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.squareup.okio:okio:1.13.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: net.coreprotect:coreprotect:2.15.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.bukkit:bukkit:1.13-R0.1-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.sk89q.worldguard:worldguard-legacy:6.2" level="project" />
   </component>
 </module>

--- a/src/main/java/me/totalfreedom/totalfreedommod/TotalFreedomMod.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/TotalFreedomMod.java
@@ -310,7 +310,8 @@ public class TotalFreedomMod extends AeroPlugin<TotalFreedomMod>
                 version = props.getProperty("buildVersion", pluginVersion);
                 number = props.getProperty("buildNumber", "1");
                 date = props.getProperty("buildDate", "unknown");
-                head = props.getProperty("buildHead", "unknown");
+                // Need to do this or it will display ${git.commit.id.abbrev}
+                head = props.getProperty("buildHead", "unknown").replace("${git.commit.id.abbrev}", "unknown");
             }
             catch (Exception ex)
             {

--- a/src/main/java/me/totalfreedom/totalfreedommod/blocking/command/CommandBlockerEntry.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/blocking/command/CommandBlockerEntry.java
@@ -6,6 +6,7 @@ import me.totalfreedom.totalfreedommod.util.FUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.spigotmc.SpigotConfig;
 
 public class CommandBlockerEntry
 {
@@ -45,7 +46,7 @@ public class CommandBlockerEntry
         }
         if (action == CommandBlockerAction.BLOCK_UNKNOWN)
         {
-            FUtil.playerMsg(sender, "Unknown command. Type \"/help\" for help.", ChatColor.RESET);
+            sender.sendMessage(SpigotConfig.unknownCommandMessage);
             return;
         }
         FUtil.playerMsg(sender, FUtil.colorize(message));

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_overlord.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_overlord.java
@@ -7,10 +7,10 @@ import me.totalfreedom.totalfreedommod.rank.Rank;
 import net.pravian.aero.util.Ips;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.spigotmc.SpigotConfig;
 
 @CommandPermissions(level = Rank.IMPOSTOR, source = SourceType.ONLY_IN_GAME)
 @CommandParameters(description = "Overlord - control this server in-game", usage = "access", aliases = "ov")
@@ -32,7 +32,7 @@ public class Command_overlord extends FreedomCommand
             }
             catch (Exception ignored)
             {
-                msg(ChatColor.WHITE + "Unknown command. Type \"/help\" for help.");
+                sender.sendMessage(SpigotConfig.unknownCommandMessage);
                 return true;
             }
         }


### PR DESCRIPTION
- If there is no .git directory it would previously show ${git.commit.id.abbrev}, and now it will just show unknown (as intended)
- The "unknown command" message is no longer hardcoded. It uses the one from the spigot.yml so it matches with custom unknown command messages