### PR TITLE
[TFM HTTPD] Added .schem as a possible extension for /schematic/list

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/httpd/module/Module_schematic.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/httpd/module/Module_schematic.java
@@ -30,7 +30,8 @@ public class Module_schematic extends HTTPDModule
     private static final Pattern SCHEMATIC_FILENAME_LC = Pattern.compile("^[a-z0-9_'!,\\-]*\\.(schem|schematic)$");
     private static final String[] SCHEMATIC_FILTER = new String[]
             {
-                    "schematic"
+                    "schematic",
+					"schem"
             };
     private static final String UPLOAD_FORM = "<form method=\"post\" name=\"schematicForm\" id=\"schematicForm\" action=\"/schematic/upload/\" enctype=\"multipart/form-data\">\n"
             + "<p>Select a schematic file to upload. Filenames must be alphanumeric, between 1 and 30 characters long (inclusive), and have a .schematic extension.</p>\n"

--- a/src/main/java/me/totalfreedom/totalfreedommod/httpd/module/Module_schematic.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/httpd/module/Module_schematic.java
@@ -31,7 +31,7 @@ public class Module_schematic extends HTTPDModule
     private static final String[] SCHEMATIC_FILTER = new String[]
             {
                     "schematic",
-					"schem"
+		    "schem"
             };
     private static final String UPLOAD_FORM = "<form method=\"post\" name=\"schematicForm\" id=\"schematicForm\" action=\"/schematic/upload/\" enctype=\"multipart/form-data\">\n"
             + "<p>Select a schematic file to upload. Filenames must be alphanumeric, between 1 and 30 characters long (inclusive), and have a .schematic extension.</p>\n"


### PR DESCRIPTION
Schematics (for whatever reason) now automatically save in the .schem extension by default, which would not be listed by the HTTPD server when accessing _/schematic/list_. This pull request corrects the issue. The code has been tested and it worked as expected.