### PR TITLE
Block death potions

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/blocking/PotionBlocker.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/blocking/PotionBlocker.java
@@ -80,7 +80,8 @@ public class PotionBlocker extends FreedomService
     {
         for (PotionEffect effect : effects)
         {
-            if (effect.getType().equals(PotionEffectType.HEAL) && effect.getAmplifier() == 125)
+            int amplifier = effect.getAmplifier();
+            if (effect.getType().equals(PotionEffectType.HEAL) && (amplifier == 29 || amplifier == 61 || amplifier == 93 || amplifier == 125))
             {
                 return true;
             }


### PR DESCRIPTION
Blocks all known death potions as it's possible to use amplifier 29, 61, 93 and 125 to get the same effect from it.
This is even mentioned in the [Minecraft Gamepedia](https://minecraft.gamepedia.com/Instant_Health) that:
> Amplifiers outside the range 0–31 (corresponding to levels 1–32) are used modulo 32.