### PR TITLE
Grammar fix for command_setlevel.java

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_setlevel.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_setlevel.java
@@ -7,7 +7,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 @CommandPermissions(level = Rank.OP, source = SourceType.ONLY_IN_GAME)
-@CommandParameters(description = "Sets your expierence level.", usage = "/<command> [level]")
+@CommandParameters(description = "Sets your experience level.", usage = "/<command> [level]")
 public class Command_setlevel extends FreedomCommand
 {
 


### PR DESCRIPTION
I catch these as I edit my own fork, I've made one or two other grammar pulls. If these are annoying or unnecessary, let me know