### PR TITLE
add command which lets super admins change the entity cap

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
@@ -4,13 +4,13 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.EntitySpawnEvent;
 import me.totalfreedom.totalfreedommod.config.ConfigEntry;
 
 public class EntityWiper extends FreedomService
 {   
-    private BukkitTask wiper;
 
     public EntityWiper(TotalFreedomMod plugin)
     {
@@ -20,27 +20,23 @@ public class EntityWiper extends FreedomService
     @Override
     protected void onStart()
     {   
-        wiper = new BukkitRunnable()
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onEntitySpawn(EntitySpawnEvent event)
+    {
+        for (World world : Bukkit.getWorlds())
         {
-            @Override
-            public void run()
+            if (world.getEntities().size() > ConfigEntry.ENTITY_LIMIT.getInteger())
             {
-                for (World world : Bukkit.getWorlds())
-                {
-                    if (world.getEntities().size() > ConfigEntry.ENTITY_LIMIT.getInteger())
-                    {
-                        wipe(world);
-                    }
-                }
+                wipe(world);
             }
-        }.runTaskTimer(plugin, 0, 5);
+        }
     }
 
     @Override
     protected void onStop()
     {
-        wiper.cancel();
-        wiper = null;
     }
 
     // Methods for wiping

--- a/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
@@ -6,13 +6,10 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import me.totalfreedom.totalfreedommod.config.ConfigEntry;
 
 public class EntityWiper extends FreedomService
 {   
-    List<Integer> entitycap = new ArrayList<Integer>();
     private BukkitTask wiper;
 
     public EntityWiper(TotalFreedomMod plugin)
@@ -23,7 +20,6 @@ public class EntityWiper extends FreedomService
     @Override
     protected void onStart()
     {   
-        entitycap.add(400);
         wiper = new BukkitRunnable()
         {
             @Override
@@ -31,7 +27,7 @@ public class EntityWiper extends FreedomService
             {
                 for (World world : Bukkit.getWorlds())
                 {
-                    if (world.getEntities().size() > entitycap.get(0))
+                    if (world.getEntities().size() > ConfigEntry.ENTITY_LIMIT.getInteger())
                     {
                         wipe(world);
                     }
@@ -82,8 +78,7 @@ public class EntityWiper extends FreedomService
 
     public int setEntityCap(int integer)
     {
-        entitycap.removeAll(entitycap);
-        entitycap.add(integer);
+        ConfigEntry.ENTITY_LIMIT.setInteger(integer);
         return integer;
     }
 }

--- a/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
@@ -29,6 +29,7 @@ public class EntityWiper extends FreedomService
         {
             if (world.getEntities().size() > ConfigEntry.ENTITY_LIMIT.getInteger())
             {
+                event.setCancelled(true);
                 wipe(world);
             }
         }

--- a/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
@@ -1,17 +1,18 @@
 package me.totalfreedom.totalfreedommod;
 
-import java.util.Arrays;
-import java.util.List;
-import me.totalfreedom.totalfreedommod.util.Groups;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class EntityWiper extends FreedomService
-{
+{   
+    List<Integer> entitycap = new ArrayList<Integer>();
     private BukkitTask wiper;
 
     public EntityWiper(TotalFreedomMod plugin)
@@ -19,27 +20,24 @@ public class EntityWiper extends FreedomService
         super(plugin);
     }
 
-    public List<EntityType> BLACKLIST = Arrays.asList(
-            EntityType.ARMOR_STAND,
-            EntityType.PAINTING,
-            EntityType.BOAT,
-            EntityType.PLAYER,
-            EntityType.LEASH_HITCH,
-            EntityType.ITEM_FRAME
-    );
-
     @Override
     protected void onStart()
-    {
-        // Continuous Entity Wiper
+    {   
+        entitycap.add(400);
         wiper = new BukkitRunnable()
         {
             @Override
             public void run()
             {
-                wipe();
+                for (World world : Bukkit.getWorlds())
+                {
+                    if (world.getEntities().size() > entitycap.get(0))
+                    {
+                        wipe(world);
+                    }
+                }
             }
-        }.runTaskTimer(plugin, 1L, 300 * 5); // 5 minutes
+        }.runTaskTimer(plugin, 0, 5);
     }
 
     @Override
@@ -58,7 +56,7 @@ public class EntityWiper extends FreedomService
         {
             for (Entity entity : world.getEntities())
             {
-                if (!BLACKLIST.contains(entity.getType()) && !Groups.MOB_TYPES.contains(entity.getType()))
+                if (!(entity instanceof Player))
                 {
                     entity.remove();
                     removed++;
@@ -66,5 +64,26 @@ public class EntityWiper extends FreedomService
             }
         }
         return removed;
+    }
+
+    public int wipe(World world)
+    {
+        int removed = 0;
+        for (Entity entity : world.getEntities())
+        {
+            if (!(entity instanceof Player))
+            {
+                entity.remove();
+                removed++;
+            }
+        }
+        return removed;
+    }
+
+    public int setEntityCap(int integer)
+    {
+        entitycap.removeAll(entitycap);
+        entitycap.add(integer);
+        return integer;
     }
 }

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_entitycap.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_entitycap.java
@@ -23,15 +23,15 @@ public class Command_entitycap extends FreedomCommand
         {
             FUtil.adminAction(sender.getName(), "Resetting the entity limit" , true); 
             plugin.ew.setEntityCap(400); 
-            msg("Successfully reset the entity cap.");
+            msg("Successfully reset the entity limit.");
             return true;
         }
 
         if (StringUtils.isNumeric(args[0]))
         {
-            FUtil.adminAction(sender.getName(), "Setting entity limit to " + Integer.parseInt(args[0]), true);
+            FUtil.adminAction(sender.getName(), "Setting the entity limit to " + Integer.parseInt(args[0]), true);
             int removed = plugin.ew.setEntityCap(Integer.parseInt(args[0]));
-            msg("Successfully set the entity cap.");
+            msg("Successfully set the entity limit.");
         } else
         {
             return false;

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_entitycap.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_entitycap.java
@@ -1,0 +1,41 @@
+package me.totalfreedom.totalfreedommod.command;
+
+import me.totalfreedom.totalfreedommod.rank.Rank;
+import me.totalfreedom.totalfreedommod.util.FUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.apache.commons.lang3.StringUtils;
+import java.lang.Integer;
+
+@CommandPermissions(level = Rank.SUPER_ADMIN, source = SourceType.BOTH)
+@CommandParameters(description = "Sets the maximum allowed number of entites until they are removed.", usage = "/<command> <integer>", aliases = "ecap")
+public class Command_entitycap extends FreedomCommand
+{
+
+    @Override
+    public boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
+    {
+        if (args.length < 1)
+        {
+            FUtil.adminAction(sender.getName(), "Resetting the entity limit" , true); 
+            plugin.ew.setEntityCap(400); 
+            msg("Successfully reset the entity cap.");
+            return true;
+        }
+
+        if (StringUtils.isNumeric(args[0]))
+        {
+            FUtil.adminAction(sender.getName(), "Setting entity limit to " + Integer.parseInt(args[0]), true);
+            int removed = plugin.ew.setEntityCap(Integer.parseInt(args[0]));
+            msg("Successfully set the entity cap.");
+        } else
+        {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/me/totalfreedom/totalfreedommod/config/ConfigEntry.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/config/ConfigEntry.java
@@ -142,6 +142,7 @@ public enum ConfigEntry
     VOTING_INFO(List.class, "votinginfo"), 
     MASTER_BUILDER_INFO(List.class, "masterbuilderinfo"),
     AUTO_ENTITY_WIPE(Boolean.class, "auto_wipe"),
+    TOGGLE_CHAT(Boolean.class, "toggle_chat"),
     ENTITY_LIMIT(Integer.class, "entity.limit"),
     //
     AMP_ENABLED(Boolean.class, "amp.enabled"),

--- a/src/main/java/me/totalfreedom/totalfreedommod/config/ConfigEntry.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/config/ConfigEntry.java
@@ -9,6 +9,7 @@ public enum ConfigEntry
     FORCE_IP_ENABLED(Boolean.class, "forceip.enabled"),
     FORCE_IP_PORT(Integer.class, "forceip.port"),
     FORCE_IP_KICKMSG(String.class, "forceip.kickmsg"),
+
     //
     ALLOW_EXPLOSIONS(Boolean.class, "allow.explosions"),
     ALLOW_FIRE_PLACE(Boolean.class, "allow.fire_place"),
@@ -141,7 +142,7 @@ public enum ConfigEntry
     VOTING_INFO(List.class, "votinginfo"), 
     MASTER_BUILDER_INFO(List.class, "masterbuilderinfo"),
     AUTO_ENTITY_WIPE(Boolean.class, "auto_wipe"),
-    TOGGLE_CHAT(Boolean.class, "toggle_chat"),
+    ENTITY_LIMIT(Integer.class, "entity.limit"),
     //
     AMP_ENABLED(Boolean.class, "amp.enabled"),
     AMP_USERNAME(String.class, "amp.username"),

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -452,6 +452,9 @@ autokick:
 # Blocked Chat Codes - Use &code,&code2,&code3 (No spaces)
 blocked_chatcodes: '&0,&k,&m,&n'
 
+# Toggle Chat
+toggle_chat: true
+
 # AMP Integration, used to restart server (optional, without it, have to start server manually after stop)
 amp:
   enabled: false

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -304,9 +304,6 @@ flatlands:
 # Admin-Only Mode
 admin_only_mode: false
 
-# Toggle Chat
-toggle_chat: true
-
 # Protected Areas - Protect areas so that only admins can directly modify blocks in those areas. WorldEdit and other such plugins might bypass this.
 protectarea:
   enabled: true
@@ -461,3 +458,6 @@ amp:
   username: username
   password: password
   url: url
+
+entity:
+  limit: 400


### PR DESCRIPTION
this does 2 things

create a command (/entitycap)

- typing /entitycap will reset the entity cap back to 400

- typing /entitycap 200 will set the entity cap to 200

revert entitywiper back to supers version

-  seths version of entitywiper is kinda bad because it allows for the creation of massive amounts of entities crashing out the server before the server has a chance to clear them

and yes this actually does have a use this time, it allows for admins to dynamically control the entity wiper cap so it can be adjusted as needed