### PR TITLE
Add bees to EntityWiper blacklist (#171)

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
@@ -25,7 +25,8 @@ public class EntityWiper extends FreedomService
             EntityType.BOAT,
             EntityType.PLAYER,
             EntityType.LEASH_HITCH,
-            EntityType.ITEM_FRAME
+            EntityType.ITEM_FRAME,
+            EntityType.BEE
     );
 
     @Override


### PR DESCRIPTION
Stop bees from being wiped, as it puts Minecraft into a state of infinitely trying to create bees, as per #171.