### PR TITLE
Don't kill bees on scheduled EntityWipe (#171)

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/EntityWiper.java
@@ -37,7 +37,7 @@ public class EntityWiper extends FreedomService
             @Override
             public void run()
             {
-                wipe();
+                wipe(true);
             }
         }.runTaskTimer(plugin, 1L, 300 * 5); // 5 minutes
     }
@@ -51,14 +51,17 @@ public class EntityWiper extends FreedomService
 
     // Methods for wiping
 
-    public int wipe()
+    public int wipe(boolean isScheduled)
     {
         int removed = 0;
         for (World world : Bukkit.getWorlds())
         {
             for (Entity entity : world.getEntities())
             {
-                if (!BLACKLIST.contains(entity.getType()) && !Groups.MOB_TYPES.contains(entity.getType()))
+                EntityType type = entity.getType();
+                if (!BLACKLIST.contains(type) && !Groups.MOB_TYPES.contains(type)
+                        // Don't kill bees on scheduled wipes (#171) #SaveTheBees
+                        && !(isScheduled && type == EntityType.BEE))
                 {
                     entity.remove();
                     removed++;

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_entitywipe.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_entitywipe.java
@@ -18,7 +18,8 @@ public class Command_entitywipe extends FreedomCommand
     public boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
     {
         FUtil.adminAction(sender.getName(), "Removing all server entities", true);
-        int removed = plugin.ew.wipe();
+        // Pass false here to let EW know that it's not scheduled
+        int removed = plugin.ew.wipe(false);
         msg(removed + " entities removed.");
 
         return true;


### PR DESCRIPTION
Fix #171 in a way that doesn't completely block bees from being wiped.

Here's what it does:
We've added a new argument `boolean isScheduled` to `wipe()` - this is passed as `true` by the scheduler and `false` by the command. We added `*&& !(isScheduled && type == EntityType.BEE)` to cancel the wiping if it's scheduled and it's a bee.

*I also assigned the EntityType to a variable because I was not gonna have 3 `entity.getType`s in one if statement*

#SaveTheBees