### PR TITLE
Format change (/cmdspy)

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_cmdspy.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_cmdspy.java
@@ -14,9 +14,9 @@ public class Command_cmdspy extends FreedomCommand
     @Override
     public boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
     {
-        msg("CommandSpy " + (admin.getCommandSpy() ? "enabled." : "disabled."));
         Admin admin = plugin.al.getAdmin(playerSender);
         admin.setCommandSpy(!admin.getCommandSpy());
+        msg("CommandSpy " + (admin.getCommandSpy() ? "enabled." : "disabled."));
         plugin.al.save(admin);
         plugin.al.updateTables();
 

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_cmdspy.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_cmdspy.java
@@ -14,12 +14,11 @@ public class Command_cmdspy extends FreedomCommand
     @Override
     public boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
     {
-
+        msg("CommandSpy " + (admin.getCommandSpy() ? "enabled." : "disabled."));
         Admin admin = plugin.al.getAdmin(playerSender);
         admin.setCommandSpy(!admin.getCommandSpy());
         plugin.al.save(admin);
         plugin.al.updateTables();
-        msg("CommandSpy " + (admin.getCommandSpy() ? "enabled." : "disabled."));
 
         return true;
     }


### PR DESCRIPTION
While executing this during administration I noticed the ratio between execution and response was rather delayed, and I realized it's because the command is waiting for all the tables to save before sending the player the enabled/disabled message. This creates a false sense of lag and is as simple as making the message run before anything else, given that the tables save almost instantly, this won't negatively affect the module or command.