### PR TITLE
Removed "Build" "break-block" and "place-block"

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/world/WorldRestrictions.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/world/WorldRestrictions.java
@@ -30,9 +30,6 @@ public class WorldRestrictions extends FreedomService
 
     private final Map<Flag<?>, Object> flags = new HashMap<Flag<?>, Object>()
     {{
-        put(Flags.BLOCK_PLACE, StateFlag.State.DENY);
-        put(Flags.BLOCK_BREAK, StateFlag.State.DENY);
-        put(Flags.BUILD, StateFlag.State.DENY);
         put(Flags.PLACE_VEHICLE, StateFlag.State.DENY);
         put(Flags.DESTROY_VEHICLE, StateFlag.State.DENY);
         put(Flags.ENTITY_ITEM_FRAME_DESTROY, StateFlag.State.DENY);


### PR DESCRIPTION
removed these flags from restricted worlds due to it breaking gravity blocks, redstone, pistons, and various other things, blocks still cant be broken due to the onblockplace and onblockbreak event handlers

idk how to add this but /summon, /spawnmob, /etree, /ebigtree, and any of those commands aliases also need to be blocked due to them being able to bypass these restrictions